### PR TITLE
Ignore CI errors on Nightly Rust

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,24 +49,28 @@ jobs:
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: check
           args: --manifest-path rust/Cargo.toml
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: fmt
           args: --manifest-path rust/Cargo.toml --all -- --check
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: clippy
           args: --manifest-path rust/Cargo.toml -- -D warnings -W clippy::nursery
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
         with:
           command: test
           args: --manifest-path rust/Cargo.toml --release --all-features

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - beta
           - nightly
     steps:
       - uses: actions/checkout@v2

--- a/rust/src/bin/optimal_bms.rs
+++ b/rust/src/bin/optimal_bms.rs
@@ -60,10 +60,7 @@ fn main() -> io::Result<()> {
     let r = satcomp::bidirectional_parse::find_in_range(
         &text,
         opt.minsize,
-        match opt.maxsize {
-            None => usize::MAX,
-            Some(x) => x,
-        },
+        opt.maxsize.map_or(usize::MAX, |x| x),
         opt.first_phrase_len,
     );
     if let Some(bd) = r {


### PR DESCRIPTION
This PR ignores all errors related to Nightly Rust because following those errors imposes unnecessary maintenance costs. This PR also removes the Beta option because there is no longer a demand for this option.