### PR TITLE
Type-annotate SLP solver and introduce SLPNode

### DIFF
--- a/src/bms_solver.py
+++ b/src/bms_solver.py
@@ -60,7 +60,8 @@ class BiDirLiteralManager(LiteralManager):
     def newid(self, *obj):
         res = super().newid(*obj)
         if len(obj) > 0 and obj[0] in self.verifyf:
-            self.verifyf[obj[0]](obj)
+            # @TODO resolve type errors
+            self.verifyf[obj[0]](obj)  # type:ignore
         return res
 
     def verify_pstart(self, obj: Tuple[str, int]):

--- a/src/mysat.py
+++ b/src/mysat.py
@@ -31,7 +31,7 @@ class LiteralManager:
         self.true = self.newsym(self.lits.true)
         self.false = self.newsym(self.lits.false)
 
-    def newid(self, *obj):
+    def newid(self, *obj: object) -> int:
         if len(obj) == 0:
             # obj = ("auxlit", self.nvar["auxlit"])
             obj = (self.lits.auxlit, self.nvar[self.lits.auxlit])

--- a/src/slp.py
+++ b/src/slp.py
@@ -18,11 +18,14 @@ from pysat.formula import WCNF
 #     Tuple[SLPNodeType, Dict[SLPNodeType, Optional[Tuple[SLPNodeType, SLPNodeType]]]],
 # )
 
+SLPNode = NewType("SLPNode", Tuple[int, int, Optional[int]])
+# root node, dict mapping nodes to list of children
+SLPMulti = NewType("SLPMulti", Tuple[SLPNode, Dict[SLPNode, List[SLPNode]]])
 SLPType = NewType(
     "SLPType",
     Tuple[
-        Tuple[int, int, Optional[int]],  # root node
-        Dict[Tuple[int, int, Optional[int]], List[Tuple[int, int, Optional[int]]]],  # children
+        SLPNode,  # root node
+        Dict[SLPNode, Tuple[SLPNode, SLPNode] | None],  # children
     ],
 )
 


### PR DESCRIPTION
## Summary
- Introduces `SLPNode` as a `NewType` and updates `SLPType` to represent a *binary* SLP (`node -> (left, right) | None`).
- Adds `SLPMulti` for the intermediate multi-ary tree produced during recovery, then deterministically binarizes it.
- Refactors `SLPLiteralManager` to use explicit `add_*` helpers instead of overriding `newid`, keeping runtime assertions while improving type safety.
- Adds/adjusts type annotations in `slp_solver.py` (e.g., `postorder_cmp`, `build_slp_aux`, `binarize_slp`, `slp2str`, `recover_slp`).
- Tightens `LiteralManager.newid` typing and silences a remaining type issue in `bms_solver.py` (TODO left in place).

## Motivation
Reduce IDE/mypy/Pylance type errors and make the SLP representation explicit (multi-ary during construction, binary for the final SLP).

## Notes
- The `bms_solver.py` `type: ignore` is a temporary workaround; we should revisit the verification callback types separately.
