### PR TITLE
Add concise docstrings across src modules

### DIFF
--- a/src/attractor.py
+++ b/src/attractor.py
@@ -1,3 +1,5 @@
+"""Utilities for verifying (and experimenting with) string attractors."""
+
 from typing import List, NewType
 
 import stralgo
@@ -6,9 +8,7 @@ AttractorType = NewType("AttractorType", List[int])
 
 
 def verify_attractor(text: bytes, attractor: AttractorType) -> bool:
-    """
-    Verify the attractor.
-    """
+    """Verify the attractor."""
 
     # run fast
     sa = stralgo.make_sa_MM(text)

--- a/src/attractor_bench.py
+++ b/src/attractor_bench.py
@@ -1,3 +1,5 @@
+"""Benchmark runner for minimum string attractor algorithms."""
+
 import argparse
 import datetime
 import os
@@ -19,6 +21,7 @@ algos = ["solver"]
 
 
 def run_solver(input_file: str, timeout: Optional[float] = None) -> Optional[AttractorExp]:
+    """Run `src/attractor_solver.py` on a single input file and parse its JSON output."""
     cmd = [
         "uv",
         "run",
@@ -68,9 +71,7 @@ def run_solver(input_file: str, timeout: Optional[float] = None) -> Optional[Att
 
 
 def benchmark_program(timeout: float | None, algo: str, file: str) -> None:
-    """
-    Runs program with given setting (timeout, algo, file).
-    """
+    """Run the program with a given (timeout, algo, file) setting."""
     if algo == "solver":
         exp = run_solver(file, timeout)
     else:
@@ -93,16 +94,12 @@ def benchmark_program(timeout: float | None, algo: str, file: str) -> None:
 
 
 def benchmark_mul(timeout: float | None, algos: list[str], files: list[str], n_jobs: int) -> None:
-    """
-    Run benchmark program with multiple processes
-    """
+    """Run the benchmark with multiple processes."""
     Parallel(n_jobs=n_jobs)([delayed(benchmark_program)(timeout, algo, file) for file in files for algo in algos])
 
 
 def clear_table():
-    """
-    Delete table if exists, and create new table.
-    """
+    """Delete the table if it exists, then create a new one."""
     con = sqlite3.connect(dbname)
     cur = con.cursor()
     exp = AttractorExp.create()
@@ -116,9 +113,7 @@ def clear_table():
 
 
 def export_csv(out_file: str) -> None:
-    """
-    Store table as csv format in `out_file`.
-    """
+    """Store the SQLite table as a CSV file in `out_file`."""
     con = sqlite3.connect(dbname)
     import pandas as pd
 
@@ -127,6 +122,7 @@ def export_csv(out_file: str) -> None:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
     parser = argparse.ArgumentParser(
         description="Run benchmark for algorithms computing the smallest bidirectional macro scheme (BMS)."
     )

--- a/src/attractor_bench_format.py
+++ b/src/attractor_bench_format.py
@@ -1,3 +1,5 @@
+"""Format for attractor benchmark."""
+
 from __future__ import annotations
 
 import datetime
@@ -13,6 +15,8 @@ from attractor import AttractorType
 @dataclass_json
 @dataclass
 class AttractorExp:
+    """Serializable experiment record for an attractor run (solver output + stats)."""
+
     date: str
     status: str
     algo: str
@@ -29,7 +33,8 @@ class AttractorExp:
     factor_size: int
     factors: Union[Any, AttractorType]
 
-    def fill(self, wcnf: WCNF):
+    def fill(self, wcnf: WCNF) -> None:
+        """Fill the experiment with the solution."""
         self.sol_nvars = wcnf.nv
         self.sol_nhard = len(wcnf.hard)
         self.sol_nsoft = len(wcnf.soft)
@@ -45,6 +50,7 @@ class AttractorExp:
 
     @classmethod
     def create(cls) -> AttractorExp:
+        """Create a new experiment."""
         return AttractorExp(
             date=str(datetime.datetime.now()),
             status="",

--- a/src/attractor_naive.py
+++ b/src/attractor_naive.py
@@ -1,3 +1,5 @@
+"""Naive (exponential-time) algorithms for minimum string attractors."""
+
 import argparse
 import sys
 import time
@@ -8,6 +10,7 @@ from itertools import combinations
 
 
 def blocks_ranges(w: bytes) -> dict[bytes, list[set[int]]]:
+    """Return, for each substring, the list of occurrence position-sets."""
     blocks = dict()
     for i in range(len(w)):
         for j in range(i + 1, len(w) + 1):
@@ -20,6 +23,7 @@ def blocks_ranges(w: bytes) -> dict[bytes, list[set[int]]]:
 
 
 def is_attractor(S: set[int], w: bytes) -> bool:
+    """Check whether `S` hits every distinct substring occurrence of `w`."""
     br = blocks_ranges(w)
     for b in br:
         for i in range(len(br[b])):
@@ -31,6 +35,7 @@ def is_attractor(S: set[int], w: bytes) -> bool:
 
 
 def lsa(w: bytes) -> int:  # length of smallest attractor of w
+    """Return the length of a smallest string attractor (brute force)."""
     for r in range(1, len(w) + 1):
         for s in combinations(range(len(w)), r):
             if is_attractor(set(s), w):
@@ -44,6 +49,7 @@ def lsa(w: bytes) -> int:  # length of smallest attractor of w
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description="Compute Minimum String Attractors.")
     parser.add_argument("--file", type=str, help="input file", default="")
     parser.add_argument("--str", type=str, help="input string", default="")

--- a/src/attractor_solver.py
+++ b/src/attractor_solver.py
@@ -1,5 +1,7 @@
 # Compute minimum string attractors by pysat
 
+"""Compute minimum string attractors using a SAT/MaxSAT formulation."""
+
 import argparse
 import json
 import os
@@ -32,9 +34,7 @@ logger.addHandler(handler)
 
 
 def min_substr_hist(min_substrs: list[tuple[int, int]], th: int) -> None:
-    """
-    Plot histogram of string lengths less than the threshold.
-    """
+    """Plot a histogram of substring lengths relative to the threshold."""
     # histogram
     nmin_substrs_th1 = [l for b, l in min_substrs if l < th]
     nmin_substrs_th2 = [l for b, l in min_substrs if l >= th]
@@ -124,9 +124,7 @@ def attractor_of_size(text: bytes, k: int, op: str, exp: Optional[AttractorExp] 
 
 
 def min_attractor_WCNF(text: bytes) -> WCNF:
-    """
-    Compute the max sat formula for computing the minimum string attractor.
-    """
+    """Compute a MaxSAT formula for the minimum string attractor problem."""
     n = len(text)
 
     sa = stralgo.make_sa_MM(text)
@@ -149,9 +147,7 @@ def min_attractor_WCNF(text: bytes) -> WCNF:
 
 
 def min_attractor(text: bytes, exp: Optional[AttractorExp] = None, contain_list: List[int] = []) -> AttractorType:
-    """
-    Compute the minimum string attractor.
-    """
+    """Compute a minimum string attractor."""
     total_start = time.time()
     wcnf = min_attractor_WCNF(text)
     for i in contain_list:
@@ -174,6 +170,7 @@ def min_attractor(text: bytes, exp: Optional[AttractorExp] = None, contain_list:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description="Compute Minimum String Attractors.")
     parser.add_argument("--file", type=str, help="input file", default="")
     parser.add_argument("--str", type=str, help="input string", default="")

--- a/src/benchmark_common.py
+++ b/src/benchmark_common.py
@@ -1,3 +1,5 @@
+"""Helpers for aggregating benchmark results into CSV tables."""
+
 import csv
 import sqlite3
 
@@ -9,6 +11,7 @@ dbname = "out/satcomp.db"
 
 
 def comp_bench(out_file: str, target_key: str, target_none: str):
+    """Write an aggregated benchmark CSV from the per-task SQLite tables."""
     con = sqlite3.connect(dbname)
     cur = con.cursor()
     cur.execute(f"select file_name from {lz_bench.dbtable}")

--- a/src/bms.py
+++ b/src/bms.py
@@ -1,3 +1,5 @@
+"""Data structures and utilities for bidirectional macro schemes (BMS)."""
+
 from __future__ import annotations
 
 import datetime
@@ -14,6 +16,8 @@ BiDirType = NewType("BiDirType", List[Tuple[int, int]])
 @dataclass_json
 @dataclass
 class BiDirExp:
+    """Serializable experiment record for a BMS run (solver output + stats)."""
+
     date: str
     status: str
     algo: str
@@ -30,7 +34,8 @@ class BiDirExp:
     factor_size: int
     factors: BiDirType
 
-    def fill(self, wcnf: WCNF):
+    def fill(self, wcnf: WCNF) -> None:
+        """Fill solver statistics from a `WCNF` instance."""
         self.sol_nvars = wcnf.nv
         self.sol_nhard = len(wcnf.hard)
         self.sol_nsoft = len(wcnf.soft)
@@ -46,6 +51,7 @@ class BiDirExp:
 
     @classmethod
     def create(cls) -> BiDirExp:
+        """Create an empty/default experiment record."""
         return BiDirExp(
             date=str(datetime.datetime.now()),
             status="",
@@ -66,6 +72,7 @@ class BiDirExp:
 
 
 def bd_info(bd: BiDirType, text: bytes) -> str:
+    """Return a human-readable summary for a decoded BMS."""
     return "\n".join(
         [
             f"len={len(bd)}: factors={bd}",
@@ -77,9 +84,7 @@ def bd_info(bd: BiDirType, text: bytes) -> str:
 
 
 def decode_len(factors: BiDirType) -> int:
-    """
-    Computes the length of decoded string from a given bidirectional macro scheme (BMS).
-    """
+    """Compute the decoded string length from a BMS factor list."""
     res = 0
     for f in factors:
         res += 1 if f[0] == -1 else f[1]
@@ -87,9 +92,7 @@ def decode_len(factors: BiDirType) -> int:
 
 
 def decode(factors: BiDirType) -> bytes:
-    """
-    Computes the decoded string from a given bidirectional macro scheme (BMS).
-    """
+    """Decode and return the string represented by a BMS factor list."""
     n = decode_len(factors)
     res = [-1 for _ in range(n)]
     nfs = len(factors)

--- a/src/bms_bench.py
+++ b/src/bms_bench.py
@@ -1,3 +1,5 @@
+"""Benchmark runner for BMS implementations (solver and naive baseline)."""
+
 import argparse
 import datetime
 import os
@@ -19,6 +21,7 @@ algos = ["solver"]
 
 
 def run_naive(input_file: str, timeout: Optional[float] = None) -> BiDirExp:
+    """Run the Rust baseline implementation and wrap results as `BiDirExp`."""
     input_file = os.path.abspath(input_file)
     current_dir = os.path.abspath(".")
     os.chdir("rust")
@@ -66,6 +69,7 @@ def run_naive(input_file: str, timeout: Optional[float] = None) -> BiDirExp:
 
 
 def run_solver(input_file: str, timeout: Optional[float] = None) -> BiDirExp:
+    """Run the Python SAT-based solver and parse its JSON output."""
     cmd = [
         "uv",
         "run",
@@ -114,9 +118,7 @@ def run_solver(input_file: str, timeout: Optional[float] = None) -> BiDirExp:
 
 
 def benchmark_program(timeout: Optional[float], algo: str, file: str) -> List[str]:
-    """
-    Run program with given setting (timeout, algo, file).
-    """
+    """Run the program with a given (timeout, algo, file) setting."""
     if algo == "naive":
         exp = run_naive(file, timeout)
     elif algo == "solver":
@@ -135,9 +137,7 @@ def benchmark_program(timeout: Optional[float], algo: str, file: str) -> List[st
 
 
 def benchmark_single(timeout: Optional[float], algos: list[str], files: list[str], out_file: str) -> None:
-    """
-    Run program with single process.
-    """
+    """Run the benchmark using a single process."""
     f = open(out_file, "w")
     for file in files:
         for algo in algos:
@@ -151,9 +151,7 @@ def benchmark_single(timeout: Optional[float], algos: list[str], files: list[str
 
 
 def benchmark_mul(timeout: Optional[float], algos: list[str], files: list[str], out_file: str, n_jobs: int) -> None:
-    """
-    Run programs with multiple processes.
-    """
+    """Run the benchmark using multiple processes."""
     if os.path.exists(out_file):
         os.remove(out_file)
     queries = Parallel(n_jobs=n_jobs)(
@@ -171,9 +169,7 @@ def benchmark_mul(timeout: Optional[float], algos: list[str], files: list[str], 
 
 
 def clear_table(dbtable: str) -> None:
-    """
-    Delete table if exists, and create new table.
-    """
+    """Delete the table if it exists, then create a new one."""
     con = sqlite3.connect(dbname)
     cur = con.cursor()
     exp = BiDirExp.create()
@@ -188,9 +184,7 @@ def clear_table(dbtable: str) -> None:
 
 
 def export_csv(dbtable: str, out_file: str) -> None:
-    """
-    Export table as csv format.
-    """
+    """Export the SQLite table as a CSV file."""
     con = sqlite3.connect(dbname)
     import pandas as pd
 
@@ -199,6 +193,7 @@ def export_csv(dbtable: str, out_file: str) -> None:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
     parser = argparse.ArgumentParser(
         description="Run benchmark for algorithms computing the smallest bidirectional macro scheme (BMS)."
     )

--- a/src/bms_naive.py
+++ b/src/bms_naive.py
@@ -1,3 +1,5 @@
+"""Wrapper script for the Rust optimal-BMS implementation."""
+
 import argparse
 import os
 import subprocess
@@ -8,6 +10,7 @@ from bms import BiDirType, bd_info
 
 
 def bms_naive(input_file: str, timeout: Optional[float] = None) -> BiDirType:
+    """Run the Rust baseline and return the parsed BMS factors."""
     input_file = os.path.abspath(input_file)
     cmd = f"cd rust && cargo run --bin optimal_bms -- --input_file {input_file}"
     print(cmd)
@@ -19,6 +22,7 @@ def bms_naive(input_file: str, timeout: Optional[float] = None) -> BiDirType:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description="Compute the smallest bidirectional macro scheme (BMS).")
     parser.add_argument("--file", type=str, help="input file", default="")
 

--- a/src/csv2table.py
+++ b/src/csv2table.py
@@ -1,3 +1,5 @@
+"""Convert benchmark CSV outputs into LaTeX table snippets."""
+
 import csv
 import sys
 
@@ -50,6 +52,7 @@ def main(fname: str, vtype: str):
 
 
 def size_table(fname: str) -> None:
+    """Print a LaTeX size-only table for the given benchmark CSV."""
     res = []
     # header = ''
     with open(fname) as csvfile:
@@ -79,6 +82,7 @@ def size_table(fname: str) -> None:
 
 
 def covert(elm: str) -> str:
+    """Convert a scalar string to a LaTeX `\\num{...}` when possible."""
     trans = elm
     try:
         trans = int(elm)
@@ -92,6 +96,7 @@ def covert(elm: str) -> str:
 
 
 def naive(fname: str) -> None:
+    """Print rows in a simple `&`-separated LaTeX-friendly format."""
     with open(fname) as csvfile:
         reader = csv.reader(csvfile)
         _ = next(reader)

--- a/src/get_prefix.py
+++ b/src/get_prefix.py
@@ -1,10 +1,11 @@
-# trim the specified length prefix of given file, and save it.
+"""Trim prefixes of input files to create prefix datasets."""
 
 import glob
 import os
 
 
 def make_dataset():
+    """Create prefix-trimmed datasets for a fixed set of input corpora."""
     dirs = ["data/calgary", "data/cantrbry"]
     prefs = range(50, 500, 50)
     prefs = [10000]

--- a/src/literal_manager.py
+++ b/src/literal_manager.py
@@ -1,3 +1,5 @@
+"""A small literal manager wrapper around `pysat`'s `IDPool`."""
+
 from collections import defaultdict
 
 from pysat.card import IDPool
@@ -6,6 +8,8 @@ from sympy.logic.boolalg import Boolean
 
 
 class LiteralManager:
+    """Allocate SAT variable IDs and provide SymPy symbol views."""
+
     def __init__(self):
         self.vpool = IDPool()
         # self.top_id = 0
@@ -14,17 +18,22 @@ class LiteralManager:
         self.false = self.sym("false")
 
     def id(self, *opt: object) -> int:
+        """Return a stable integer ID for the given key tuple."""
         return self.vpool.id(opt)
 
     def sym(self, *opt: object) -> Boolean:
+        """Return a SymPy symbol representing the ID of `opt`."""
         return Symbol(str(self.id(*opt)))
 
     def symid(self, x: Boolean) -> int:
+        """Convert a SymPy symbol back to its integer ID."""
         return int(str(x))
 
     def new_var(self, name: str = "adjlm") -> int:
+        """Allocate a fresh variable ID under the given name prefix."""
         self.nvar[name] += 1
         return self.id(name, self.nvar[name])
 
     def new_var_sym(self, name: str = "adjlm") -> Boolean:
+        """Allocate a fresh variable and return it as a SymPy symbol."""
         return Symbol(str(self.new_var(name)))

--- a/src/lz77.py
+++ b/src/lz77.py
@@ -1,3 +1,5 @@
+"""LZ77 factorization (encode/decode) helpers."""
+
 # factors is 2-tuple list
 # if factors[i][0] == -1, it represents the character factors[i][1]
 # otherwise, it represents the previous appeared substring text[factors[i][0]:factors[i][0]+factors[i][1]]
@@ -10,6 +12,7 @@ LZType = NewType("LZType", List[Tuple[int, int]])
 
 
 def encode(text: bytes) -> LZType:
+    """Compute an LZ77 factorization of `text`."""
     res = LZType([])
     n = len(text)
     sa = stralgo.make_sa_MM(text)
@@ -51,10 +54,12 @@ def encode(text: bytes) -> LZType:
 
 
 def factor_strs(factors: LZType) -> List[bytes]:
+    """Return the factor strings corresponding to `factors`."""
     return decode_(factors)[0]
 
 
 def decode_(factors: LZType) -> Tuple[List[bytes], bytes]:
+    """Decode to both factor strings and the reconstructed text."""
     text = []
     res = []
     for factor in factors:
@@ -72,10 +77,12 @@ def decode_(factors: LZType) -> Tuple[List[bytes], bytes]:
 
 
 def decode(factors: LZType) -> bytes:
+    """Decode and return the reconstructed text."""
     return decode_(factors)[1]
 
 
 def equal(text: bytes, f1: LZType, f2: LZType) -> bool:
+    """Return whether two factorizations represent the same substrings in `text`."""
     # verify factor form
     if len(f1) != len(f2):
         return False

--- a/src/lz_bench.py
+++ b/src/lz_bench.py
@@ -1,3 +1,5 @@
+"""Benchmark runner for external LZ-family compressors."""
+
 # Run a benchmark for LZ77, LZRR, lcpcomp, lexparse
 # We use the following program by @TNishimoto
 # https://github.com/TNishimoto/lzrr
@@ -25,6 +27,8 @@ algos = ["lz", "lzrr", "lex", "lcp"]
 
 @dataclass
 class LZExp:
+    """Serializable experiment record for an external compressor run."""
+
     date: str
     status: str
     algo: str
@@ -35,13 +39,12 @@ class LZExp:
 
     @classmethod
     def create(cls) -> LZExp:
+        """Create an empty/default experiment record."""
         return LZExp("", "", "", "", 0, 0, 0)
 
 
 def benchmark_program(timeout: float | None, algo: str, file: str) -> List[str]:
-    """
-    Run program with given setting (timeout, algo, file).
-    """
+    """Run the external compressor with a given (timeout, algo, file) setting."""
     base_name = os.path.basename(file)
     out_file = f"out/lz/{base_name}.{algo}"
     cmd = [
@@ -83,9 +86,7 @@ def benchmark_program(timeout: float | None, algo: str, file: str) -> List[str]:
 
 
 def benchmark_mul(timeout: float | None, algos: list[str], files: list[str], out_file: str, n_jobs: int) -> None:
-    """
-    Run benchmark program with multiple processes
-    """
+    """Run the benchmark with multiple processes."""
     if os.path.exists(out_file):
         os.remove(out_file)
     queries = Parallel(n_jobs=n_jobs)(
@@ -103,9 +104,7 @@ def benchmark_mul(timeout: float | None, algos: list[str], files: list[str], out
 
 
 def clear_table(table_name: str):
-    """
-    Delete table if exists, and create new table.
-    """
+    """Delete the table if it exists, then create a new one."""
     con = sqlite3.connect(dbname)
     cur = con.cursor()
     exp = LZExp.create()
@@ -120,9 +119,7 @@ def clear_table(table_name: str):
 
 
 def export_csv(table_name: str, out_file: str) -> None:
-    """
-    Store table as csv format in `out_file`.
-    """
+    """Store the SQLite table as a CSV file in `out_file`."""
     con = sqlite3.connect(dbname)
     import pandas as pd
 
@@ -131,6 +128,7 @@ def export_csv(table_name: str, out_file: str) -> None:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
     parser = argparse.ArgumentParser(
         description="Run benchmark for algorithms computing the smallest bidirectional macro scheme (BMS)."
     )

--- a/src/min_substr.py
+++ b/src/min_substr.py
@@ -1,3 +1,5 @@
+"""Utilities for computing/inspecting minimum substrings in strings."""
+
 import argparse
 import sys
 from enum import Enum, auto
@@ -7,6 +9,8 @@ import stralgo
 
 
 class Mode(Enum):
+    """Mode selector for the `min_substr` CLI."""
+
     size_min_substr = auto()
     size_min_right_substr = auto()
     test = auto()
@@ -14,6 +18,7 @@ class Mode(Enum):
 
 
 def main(input_file: str) -> None:
+    """Print the number of minimum substrings for the file."""
     print(input_file)
     with open(input_file, "rb") as f:
         text = f.read()
@@ -28,6 +33,7 @@ def main(input_file: str) -> None:
 
 
 def test():
+    """Run a small self-check on a tiny example string."""
     text = b"ab"
     assert len(stralgo.minimum_substr(text)) == 2
     pos_lens = stralgo.minimum_substr(text)
@@ -39,6 +45,7 @@ def test():
 
 
 def exp():
+    """Run a small experiment over a fixed file list and print summary stats."""
     files = [
         "data/calgary/bib",
         "data/calgary/book1",
@@ -125,11 +132,13 @@ def exp():
 
 
 def show(text: AnyStr, substrs: List[Tuple[int, int]]):
+    """Print each substring occurrence `(pos, length)` as an extracted slice."""
     for i, l in substrs:
         print(text[i : i + l])
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments and normalize `mode` into a `Mode` enum value."""
     parser = argparse.ArgumentParser(description="Compute Minimum SLP.")
     parser.add_argument("--file", type=str, help="input file", default="")
     parser.add_argument("--str", type=str, help="input string", default="")

--- a/src/mytimer.py
+++ b/src/mytimer.py
@@ -1,9 +1,13 @@
+"""Lightweight timing helper used by solvers and benchmarks."""
+
 from __future__ import annotations
 
 import time
 
 
 class Timer:
+    """Collect named timing measurements."""
+
     def __init__(self) -> None:
         self.t = time.time()
         self.times = dict()
@@ -14,5 +18,6 @@ class Timer:
         return x
 
     def record(self, name: str) -> None:
+        """Record elapsed time since last tick under `name` and reset the timer."""
         self.times[name] = time.time() - self.t
         self.t = time.time()

--- a/src/period_doubling_sequence.py
+++ b/src/period_doubling_sequence.py
@@ -1,8 +1,11 @@
+"""Generate the period-doubling sequence and write it to files."""
+
 char0 = "a"
 char1 = "b"
 
 
 def pds(text: str) -> str:
+    """Apply one period-doubling morphism step to `text`."""
     n = len(text)
     res = ""
     for i in range(n):
@@ -16,6 +19,7 @@ def pds(text: str) -> str:
 
 
 def make_dataset():
+    """Write a small sequence of period-doubling strings to `data/misc/`."""
     file_template = "data/misc/pds{}.txt"
     num = 8
     res = ["" for _ in range(num)]

--- a/src/repair.py
+++ b/src/repair.py
@@ -1,9 +1,12 @@
+"""Experimental implementation of the RePair grammar-based compressor."""
+
 import argparse
 import sys
 from typing import List, Tuple
 
 
 def mostfreq(inttext: List[int]) -> Tuple[Tuple[int, int], int]:
+    """Return the most frequent adjacent pair and its frequency."""
     frequencies = dict()
     parity = 0
     for i in range(0, len(inttext) - 1):
@@ -26,6 +29,7 @@ def mostfreq(inttext: List[int]) -> Tuple[Tuple[int, int], int]:
 
 
 def repair(text: bytes) -> int:
+    """Run a simple RePair loop and return the resulting grammar size proxy."""
     print(text)
     inttext = []
     for i in range(0, len(text)):
@@ -58,6 +62,7 @@ def repair(text: bytes) -> int:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description="Compute Minimum SLP.")
     parser.add_argument("--file", type=str, help="input file", default="")
     parser.add_argument("--str", type=str, help="input string", default="")

--- a/src/slp.py
+++ b/src/slp.py
@@ -1,3 +1,5 @@
+"""Data structures for straight-line programs (SLP) and their experiment records."""
+
 from __future__ import annotations
 
 import datetime
@@ -33,6 +35,8 @@ SLPType = NewType(
 @dataclass_json
 @dataclass
 class SLPExp:
+    """Serializable experiment record for an SLP run (solver output + stats)."""
+
     date: str
     status: str
     algo: str
@@ -49,7 +53,8 @@ class SLPExp:
     factor_size: int
     factors: str
 
-    def fill(self, wcnf: WCNF):
+    def fill(self, wcnf: WCNF) -> None:
+        """Fill solver statistics from a `WCNF` instance."""
         self.sol_nvars = wcnf.nv
         self.sol_nhard = len(wcnf.hard)
         self.sol_nsoft = len(wcnf.soft)
@@ -65,6 +70,7 @@ class SLPExp:
 
     @classmethod
     def create(cls) -> SLPExp:
+        """Create an empty/default experiment record."""
         return SLPExp(
             date=str(datetime.datetime.now()),
             status="",

--- a/src/slp_naive.py
+++ b/src/slp_naive.py
@@ -1,3 +1,5 @@
+"""Naive SLP construction/experimentation helpers."""
+
 from __future__ import annotations
 
 import argparse
@@ -27,6 +29,8 @@ logger.addHandler(handler)
 
 
 class Node(object):
+    """Binary tree node used by the naive enumeration code."""
+
     def __init__(self, left: int | Node, right: int | Node) -> None:
         self.left = left
         self.right = right
@@ -36,6 +40,7 @@ class Node(object):
 
 
 def enum_ordered(labels: bytes) -> Iterator[int | Node]:
+    """Yield all full binary trees whose leaves are `labels` in left-to-right order."""
     if len(labels) == 1:
         yield labels[0]
     else:
@@ -51,6 +56,7 @@ def enum_ordered(labels: bytes) -> Iterator[int | Node]:
 def minimize_tree(
     root: int | Node, nodedic: dict[tuple[int | Node, int | Node] | int | Node, int | Node]
 ) -> int | Node:
+    """Deduplicate identical subtrees by interning them into `nodedic`."""
     # print(root)
     if type(root) is Node:
         left = minimize_tree(root.left, nodedic)
@@ -69,6 +75,7 @@ def minimize_tree(
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description="Compute Minimum SLP.")
     parser.add_argument("--file", type=str, help="input file", default="")
     parser.add_argument("--str", type=str, help="input string", default="")

--- a/src/stralgo.py
+++ b/src/stralgo.py
@@ -1,12 +1,12 @@
+"""String algorithm utilities (SA/LCP and related helpers)."""
+
 from typing import Iterable, List, Optional, Tuple
 
 from tqdm import tqdm
 
 
 def make_sa_MM(text: bytes) -> list[int]:
-    """
-    Make sufix array by Manber and Myers algorithm.
-    """
+    """Make suffix array using the Manber-Myers algorithm."""
     if not isinstance(text, bytes):
         assert "text must be bytes"
     n = len(text)
@@ -35,6 +35,7 @@ def make_sa_MM(text: bytes) -> list[int]:
 
 
 def get_lcp(text: bytes, i: int, j: int) -> int:
+    """Return the longest common prefix length of `text[i:]` and `text[j:]`."""
     n = len(text)
     l = 0
     while i < n and j < n:
@@ -47,9 +48,7 @@ def get_lcp(text: bytes, i: int, j: int) -> int:
 
 
 def make_isa(sa: list[int]) -> list[int]:
-    """
-    Make inverse suffix array.
-    """
+    """Make the inverse suffix array."""
     n = len(sa)
     isa = [0 for _ in range(n)]
     for i in range(n):
@@ -58,9 +57,7 @@ def make_isa(sa: list[int]) -> list[int]:
 
 
 def make_lcpa_kasai(text: bytes, sa: list[int], isa: list[int] | None = None) -> list[int]:
-    """
-    Make longest common prefix array by Kasai algorithm.
-    """
+    """Make the LCP array using the Kasai algorithm."""
     n = len(text)
     if isa is None:
         isa = make_isa(sa)
@@ -76,6 +73,7 @@ def make_lcpa_kasai(text: bytes, sa: list[int], isa: list[int] | None = None) ->
 
 
 def get_bwt(text: bytes, sa: list[int]) -> list[int]:
+    """Return the Burrows-Wheeler transform of `text` given its suffix array."""
     n = len(text)
     res = []
 
@@ -103,6 +101,7 @@ def get_lcprange(lcp: List[int], i: int, least_lcp: Optional[int] = None) -> Tup
 
 
 def maximal_repeat(text: bytes, sa: list[int], lcp: list[int]) -> list[tuple[int, int]]:
+    """Compute maximal repeats using the suffix array and LCP array."""
     n = len(text)
     res = []
 
@@ -127,6 +126,7 @@ def maximal_repeat(text: bytes, sa: list[int], lcp: list[int]) -> list[tuple[int
 
 
 def occ_pos_naive(text: bytes, pattern: bytes) -> list[int]:
+    """Return all starting indices where `pattern` occurs in `text` (naive scan)."""
     res = []
     beg = 0
     occ = text.find(pattern, beg)
@@ -138,13 +138,12 @@ def occ_pos_naive(text: bytes, pattern: bytes) -> list[int]:
 
 
 def num_occ(text: bytes, pattern: bytes) -> int:
-    """
-    Compute the number of occurrences of the pattern in text.
-    """
+    """Compute the number of occurrences of `pattern` in `text`."""
     return len(occ_pos_naive(text, pattern))
 
 
 def substr(text: bytes) -> list[bytes]:
+    """Return the list of all substrings of `text` (quadratic size)."""
     n = len(text)
     res: list[bytes] = []
     for i in range(n):
@@ -172,6 +171,7 @@ def minimum_substr_naive(text: bytes) -> List[Tuple[int, int]]:
 
 
 def minimum_right_substr(text: bytes) -> list[tuple[int, int]]:
+    """Compute minimum right substrings (via SA/LCP helper)."""
     sa = make_sa_MM(text)
     isa = make_isa(sa)
     lcp = make_lcpa_kasai(text, sa, isa)
@@ -216,6 +216,7 @@ def minimum_right_substr_sa(text: bytes, sa: List[int], isa: List[int], lcp: Lis
 
 
 def minimum_substr(text: bytes) -> list[tuple[int, int]]:
+    """Compute minimum substrings (via SA/LCP helper)."""
     sa = make_sa_MM(text)
     isa = make_isa(sa)
     lcp = make_lcpa_kasai(text, sa, isa)
@@ -347,9 +348,7 @@ def minimum_substr_linear(text: bytes, sa: List[int], isa: List[int], lcp: List[
 
 
 def substr_cover(text: bytes, sa: list[int], lcp: list[int], isa: list[int], b: int, l: int) -> set[int]:
-    """
-    return occ of text[b:b+l] in text.
-    """
+    """Return the set of covered positions for all occurrences of `text[b:b+l]`."""
     lcp_range = get_lcprange(lcp, isa[b], l)
     print(lcp_range)
     cover = set()
@@ -360,12 +359,14 @@ def substr_cover(text: bytes, sa: list[int], lcp: list[int], isa: list[int], b: 
 
 
 def print_sa(text: bytes, sa: list[int]) -> None:
+    """Print a suffix array table (debug helper)."""
     n = len(text)
     for i in range(n):
         print("\t".join(map(str, [i, sa[i], text[sa[i] :]])))
 
 
 def print_sa_lcp(text: bytes, sa: list[int], lcp: list[int]) -> None:
+    """Print a suffix array + LCP table (debug helper)."""
     n = len(text)
     for i in range(n):
         print(
@@ -385,6 +386,7 @@ def print_sa_lcp(text: bytes, sa: list[int], lcp: list[int]) -> None:
 
 
 def verify_sa(text: bytes, sa: list[int]):
+    """Sanity-check that `sa` is sorted by suffix lexicographic order."""
     n = len(text)
     for i in range(1, n):
         # print('{} < {} ?'.format(text[sa[i - 1]:], text[sa[i]:]))
@@ -392,9 +394,7 @@ def verify_sa(text: bytes, sa: list[int]):
 
 
 def gen_binary(n: int) -> Iterable[str]:
-    """
-    Generates all binary strings of length `n`.
-    """
+    """Generate all binary strings of length `n` over the alphabet {a,b}."""
     if n == 1:
         yield "a"
         yield "b"


### PR DESCRIPTION
## Summary
- Adds module-level docstrings to all `src/*.py` modules.
- Adds/normalizes docstrings for public classes and functions, including benchmarks and SAT utilities.
- Converts 3-line single-sentence docstrings into one-line form (`"""text"""`) for consistency.

## Motivation
Improve readability and IDE/help() discoverability without changing behavior.

## Scope
Docstring-only changes plus minor type annotation tweaks in a few `fill()` methods.
