### PR TITLE
chore(src): remove stale commented-out code

### DIFF
--- a/src/attractor_naive.py
+++ b/src/attractor_naive.py
@@ -43,51 +43,14 @@ def lsa(w: bytes) -> int:  # length of smallest attractor of w
     raise RuntimeError("Unreachable: no attractor size found")
 
 
-# def a(n):  # only search strings starting with 0 by symmetry
-#     return max(lsa("0" + "".join(u)) for u in product("01", repeat=n - 1))
-# print([a(n) for n in range(1, 20)])
-
-
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description="Compute Minimum String Attractors.")
     parser.add_argument("--file", type=str, help="input file", default="")
     parser.add_argument("--str", type=str, help="input string", default="")
     parser.add_argument("--output", type=str, help="output file", default="")
-    # parser.add_argument(
-    #     "--contains",
-    #     nargs="+",
-    #     type=int,
-    #     help="list of text positions that must be included in the string attractor, starting with index 1",
-    #     default=[],
-    # )
-    # parser.add_argument(
-    #     "--size",
-    #     type=int,
-    #     help="exact size or upper bound of attractor size to search",
-    #     default=0,
-    # )
-    # parser.add_argument(
-    #     "--algo",
-    #     type=str,
-    #     help=(
-    #         "[min: find a minimum string attractor, exact/atmost: find a string "
-    #         "attractor whose size is exact/atmost SIZE]"
-    #     ),
-    # )
-    # parser.add_argument(
-    #     "--log_level",
-    #     type=str,
-    #     help="log level, DEBUG/INFO/CRITICAL",
-    #     default="CRITICAL",
-    # )
     args = parser.parse_args()
-    if (
-        args.file == "" and args.str == ""
-        # or args.algo not in ["exact", "atmost", "min"]
-        # or (args.algo in ["exact", "atmost"] and args.size <= 0)
-        # or (args.log_level not in ["DEBUG", "INFO", "CRITICAL"])
-    ):
+    if args.file == "" and args.str == "":
         parser.print_help()
         sys.exit()
 

--- a/src/get_prefix.py
+++ b/src/get_prefix.py
@@ -24,5 +24,4 @@ def main(in_file: str, out_file: str, pref_len: int):
 
 
 if __name__ == "__main__":
-    # main(sys.argv[1], sys.argv[2], int(sys.argv[3]))
     make_dataset()

--- a/src/lz77.py
+++ b/src/lz77.py
@@ -44,7 +44,6 @@ def encode(text: bytes) -> LZType:
             res.append((-1, text[i]))
             i += 1
         else:
-            # print(i, (psv, psv_len), (nsv, nsv_len))
             prev, prev_len = (psv, psv_len) if psv_len > nsv_len else (nsv, nsv_len)
             assert prev_len > 0
             res.append((prev, prev_len))
@@ -63,7 +62,6 @@ def decode_(factors: LZType) -> Tuple[List[bytes], bytes]:
     text = []
     res = []
     for factor in factors:
-        # print(factor, f"text length = {len(text)}")
         bs = []
         if factor[0] == -1:
             bs.append(factor[1])

--- a/src/min_substr.py
+++ b/src/min_substr.py
@@ -111,7 +111,6 @@ def exp():
         "data/misc/trib08.txt",
         "data/misc/trib09.txt",
     ]
-    # files = files[-10:]
     algos = [stralgo.minimum_substr_sa, stralgo.minimum_right_substr_sa]
     print("file, len, nlrmin, nrmin, nlrmin/nrmin, total-lrmin, total-rmin, total-lrmin/total-rmin")
     for f in files:
@@ -127,7 +126,6 @@ def exp():
             res.append(len(pos_len))
             res.append(total_len)
         line.extend([res[0], res[2], res[0] / res[2], res[1], res[3], res[1] / res[3]])
-        # print(line)
         print(",".join(map(str, line)))
 
 

--- a/src/mysat.py
+++ b/src/mysat.py
@@ -13,9 +13,6 @@ from sympy.logic.boolalg import Boolean, BooleanFalse, BooleanTrue, Equivalent, 
 
 debug = False
 
-# ClauseType = NewType("ClauseType", List[int])
-# CNFType = NewType("ClauseType", List[Clause])
-
 
 class Literal(Enum):
     """Well-known reserved literals used by `LiteralManager`."""
@@ -87,20 +84,6 @@ class LiteralManager:
         return self.vpool.top
 
 
-# def pysat_or(new_var: Callable[[], int], xs: list[int]) -> Tuple[int, list[list[int]]]:
-#     nvar = new_var()
-#     new_clauses = []
-#     # nvar <=> or(xs)
-#     # (nvar => or(xs)) and (or(xs) => nvar)
-#     # ((not nvar) OR or(xs)) and ((not or(xs)) OR nvar)
-#     # ((not nvar) OR or(xs)) and ((and(not x)) OR nvar)
-#     # ((not nvar) OR or(xs)) and (and (not x OR nvar))
-#     new_clauses.append([-nvar] + xs)
-#     for x in xs:
-#         new_clauses.append([nvar,-x])
-#     nvar, new_clauses
-
-
 def pysat_or(new_var: Callable[[], int], xs: list[int]) -> Tuple[int, list[list[int]]]:
     """Introduce a fresh variable equivalent to OR over `xs` (Tseitin encoding)."""
     nvar = new_var()
@@ -144,24 +127,13 @@ def pysat_atleast_one(xs: list[int]) -> list[int]:
     return xs
 
 
-# def pysat_exactlyone(lm: LiteralManager, xs: list[int]) -> Tuple[int, list[list[int]]]:
-#     new_clauses = pysat_atleast_one(xs)
-#     nvar, clauses = pysat_atmost(lm, xs, bound=1)
-#     new_clauses.extend(clauses)
-#     return pysat_and(lm.newid, new_clauses)
-
-
 def pysat_exactlyone(lm: LiteralManager, xs: list[int]) -> Tuple[int, list[list[int]]]:
     """Introduce a fresh variable for the CNF encoding of `exactly_one(xs)`."""
     ex1_clauses = CardEnc.atmost(xs, bound=1, vpool=lm.vpool)
-    # _, ex1_clauses = pysat_atmost(lm, xs, bound=1)
-    # res_clauses = []
     ex1_clauses.append(pysat_atleast_one(xs))
     res_var, res_clauses = pysat_name_cnf(lm, ex1_clauses)  # type: ignore
-    # res_clauses.extend(ex1_clauses)
 
     return res_var, res_clauses
-    # return pysat_name_cnf(lm, ex1_clauses)
 
 
 def pysat_name_cnf(lm: LiteralManager, xs: list[list[int]]) -> Tuple[int, list[list[int]]]:
@@ -308,7 +280,6 @@ def sympy_cnf_pysat(new_var: Callable[[], int], x: Boolean) -> list[list[int]]:
             new_clauses.append(new_clause)
             if debug:
                 print(f"{nvar}={Or(*literals)}, cnf={And(*new_clauses)}")  # type: ignore
-            # assert is_nnf(And(*new_clauses))
             new_formula.extend(new_clauses)
             return nvar
 

--- a/src/repair.py
+++ b/src/repair.py
@@ -40,9 +40,7 @@ def repair(text: bytes) -> int:
     FIRST_NONTERMINAL = 256
     last_nonterminal = FIRST_NONTERMINAL
     while True:
-        # print(inttext)
         chosen_entry = mostfreq(inttext)
-        # print(chosen_entry)
         if chosen_entry[1] == 1:
             break
         chosen_pair = chosen_entry[0]
@@ -57,7 +55,6 @@ def repair(text: bytes) -> int:
                 inttext[i] = last_nonterminal
                 inttext.pop(i + 1)
         last_nonterminal += 1
-    # print(len(inttext) + last_nonterminal - FIRST_NONTERMINAL)
     return 1 + len(inttext) + last_nonterminal - FIRST_NONTERMINAL
 
 

--- a/src/run_benchmark.sh
+++ b/src/run_benchmark.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# timeout=3600
 timeout=6
 jobs=4
 files="data/calgary/* data/misc/fib0[0-9].txt data/misc/pds* data/misc/thuemorse* data/misc/trib*"

--- a/src/slp.py
+++ b/src/slp.py
@@ -13,12 +13,6 @@ from pysat.formula import WCNF
 # if x == None -> references Node [i,j,None]
 # if x == Int -> If j-i==1, x is a leaf with symbol x, otherwise is an internal node
 # whose children are defined via a Dict
-# SLPNodeType = NewType("SLPNodeType", Tuple[int, int, Optional[int]])
-
-# SLPType = NewType(
-#     "SLPType",
-#     Tuple[SLPNodeType, Dict[SLPNodeType, Optional[Tuple[SLPNodeType, SLPNodeType]]]],
-# )
 
 SLPNode = NewType("SLPNode", Tuple[int, int, Optional[int]])
 # root node, dict mapping nodes to list of children
@@ -90,48 +84,5 @@ class SLPExp:
         )
 
 
-# def slp_info(slp: SLPType, text: bytes) -> str:
-#     return "\n".join(
-#         [
-#             f"len={len(slp)}: factors={slp}",
-#             f"len of text = {len(text)}",
-#             f"decode={decode(slp)}",
-#             f"equals original? {decode(slp)==text}",
-#         ]
-#     )
-
-
-# def decode(slp: SLPType) -> bytes:
-#     """
-#     Computes the decoded string from a given SLP
-#     """
-#     (root, slpmap) = slp
-
-#     def decode_aux(root: SLPNodeType) -> List[int]:
-#         res = []
-#         (i, j, ref) = root
-#         if j - i == 1:
-#             res.append(ref)
-#         else:
-#             children = slpmap[root]
-#             assert children != None
-#             if ref is None:
-#                 res += decode_aux(children[0])
-#                 res += decode_aux(children[1])
-#             else:
-#                 n = SLPNodeType((ref, ref + j - i, None))
-#                 res += decode_aux(n)
-#         return []
-
-#     res = []
-#     if root != None:
-#         res = decode_aux(root)
-#     return bytes(res)
-
-
 if __name__ == "__main__":
     pass
-    # factors_naive = SLPType([(13, 8), (0, 11), (-1, 98), (-1, 97)])
-    # factors_sol = SLPType([(8, 8), (13, 8), (-1, 97), (-1, 98), (16, 3)])
-    # print(decode(factors_naive))
-    # print(decode(factors_sol))

--- a/src/slp.py
+++ b/src/slp.py
@@ -82,7 +82,3 @@ class SLPExp:
             sol_nmaxclause=0,
             factors="",
         )
-
-
-if __name__ == "__main__":
-    pass

--- a/src/slp_naive.py
+++ b/src/slp_naive.py
@@ -57,7 +57,6 @@ def minimize_tree(
     root: int | Node, nodedic: dict[tuple[int | Node, int | Node] | int | Node, int | Node]
 ) -> int | Node:
     """Deduplicate identical subtrees by interning them into `nodedic`."""
-    # print(root)
     if type(root) is Node:
         left = minimize_tree(root.left, nodedic)
         right = minimize_tree(root.right, nodedic)
@@ -68,7 +67,6 @@ def minimize_tree(
             nodedic[left, right] = root
             return root
     else:
-        # print(type(root))
         if root not in nodedic:
             nodedic[root] = root
         return root

--- a/src/slp_solver.py
+++ b/src/slp_solver.py
@@ -109,7 +109,6 @@ def compute_lpf(text: bytes) -> List[int]:  # non-self-referencing lpf
                 l += 1
             if l > lpf[i]:
                 lpf[i] = l
-    # print(f"{lpf}")
     return lpf
 
 
@@ -122,7 +121,6 @@ def smallest_SLP_WCNF(
     wcnf = WCNF()
 
     lm = SLPLiteralManager(text)
-    # print("sloooow algorithm for lpf... (should use linear time algorithm)")
     lpf = compute_lpf(text)
 
     # defining the literals  ########################################
@@ -370,7 +368,6 @@ def postorder_cmp(x: SLPNode, y: SLPNode) -> typing.Literal[-1, 0, 1]:
     j1 = x[1]
     i2 = y[0]
     j2 = y[1]
-    # print(f"compare: {x} vs {y}")
     if i1 == i2 and i2 == j2:
         return 0
     if j1 <= i2:
@@ -392,11 +389,8 @@ def build_slp_aux(nodes: list[SLPNode], slp: dict[SLPNode, list[SLPNode]]) -> SL
     """Recover a multi-ary parse tree from a postorder list of nodes."""
     root = nodes.pop()
     root_i = root[0]
-    # root_j = root[1]
-    # print(f"root_i,root_j = {root_i},{root_j}")
     children = []
     while len(nodes) > 0 and nodes[-1][0] >= root_i:
-        # print(f"nodes[-1] = {nodes[-1]}")
         c = build_slp_aux(nodes, slp)
         children.append(c)
     children.reverse()
@@ -430,7 +424,6 @@ def binarize_slp(
 
 def slp2str(root: SLPNode, slp: dict[SLPNode, tuple[SLPNode, SLPNode] | None]) -> list[int]:
     """Expand an SLP back into the sequence of terminal symbols."""
-    # print(f"root={root}")
     res = []
     (i, j, ref) = root
     if j - i == 1:
@@ -491,20 +484,17 @@ def smallest_SLP(text: bytes, exp: SLPExp | None = None) -> SLPType:
         x = lm.getid(lm.lits.pstart, i)
         if x in sol:
             posl.append(i)
-    # print(f"posl={posl}")
     phrasel = []
     for occ, l in phrases:
         x = lm.getid(lm.lits.phrase, occ, l)
         if x in sol:
             phrasel.append((occ, occ + l))
-    # print(f"phrasel={phrasel}")
     refs = {}
     for j, l in refs_by_referrer.keys():
         for i in refs_by_referrer[j, l]:
             if lm.getid(lm.lits.ref, j, i, l) in sol:
                 refs[j, l] = i
     root, slp = recover_slp(text, posl, refs)
-    # print(f"root={root}, slp = {slp}, slpkeys={slp.keys()}")
 
     slpsize = len(posl) - 2 + len(set(text))
 

--- a/src/stralgo.py
+++ b/src/stralgo.py
@@ -22,7 +22,6 @@ def make_sa_MM(text: bytes) -> list[int]:
             return (key1, key2)
 
         sa.sort(key=at)
-        # print_sa(text, sa)
 
         rank2[0] = 0
         for i in range(1, n):
@@ -118,7 +117,6 @@ def maximal_repeat(text: bytes, sa: list[int], lcp: list[int]) -> list[tuple[int
     lcp_range_prev = (0, 0)
     for i in range(1, n):
         lcp_range_cur = get_lcprange(lcp, i, lcp[i])
-        # print(i, lcp_range_cur, is_bwt_distinct(lcp_range_cur))
         if lcp[i] > 0 and lcp_range_prev != lcp_range_cur and is_bwt_distinct(lcp_range_cur):
             res.append((sa[i], lcp[i]))
         lcp_range_prev = lcp_range_cur
@@ -195,7 +193,6 @@ def minimum_right_substr_sa(text: bytes, sa: List[int], isa: List[int], lcp: Lis
         if lcp[i - 1] == lcp[i]:
             continue
         lcp_range = get_lcprange(lcp, i)
-        # print(i, lcp_range)
         if (lcp_range, lcp[i]) in already_computed:
             continue
         cur = lcp_range[0]
@@ -249,8 +246,6 @@ def minimum_substr_square(text: bytes, sa: List[int], isa: List[int], lcp: List[
             continue
         lcp_range = get_lcprange(lcp, i)
         assert (lcp_range[1] - lcp_range[0] + 1) > 1
-        # for k in range(lcp_range[0], lcp_range[1]):
-        #     assert text[sa[k] : sa[k] + lcp[i]] == text[sa[k + 1] : sa[k + 1] + lcp[i]]
         if (lcp_range, lcp[i]) in already_computed:
             continue
         cur = lcp_range[0]
@@ -274,7 +269,6 @@ def minimum_substr_square(text: bytes, sa: List[int], isa: List[int], lcp: List[
                 res.append((sa[cur], lcp[i] + 1))
             assert cur < lcp_range_sub[1] + 1
             cur = lcp_range_sub[1] + 1
-    # print("#res=", len(res))
     return res
 
 
@@ -389,7 +383,6 @@ def verify_sa(text: bytes, sa: list[int]):
     """Sanity-check that `sa` is sorted by suffix lexicographic order."""
     n = len(text)
     for i in range(1, n):
-        # print('{} < {} ?'.format(text[sa[i - 1]:], text[sa[i]:]))
         assert text[sa[i - 1] :] < text[sa[i] :]
 
 


### PR DESCRIPTION
This PR removes stale commented-out code and debug prints under `src/` to improve readability and reduce noise.

- Deletes commented-out debug statements and temporary/abandoned code fragments
- Removes unused commented-out CLI argument blocks in `src/attractor_naive.py`
- Keeps explanatory comments that document behavior/constraints

No functional changes are intended; this is a cleanup-only change.